### PR TITLE
Allow including quadpack.f90 in user project

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -13,6 +13,7 @@ auto-tests = true
 
 [library]
 source-dir = "src"
+include-dir = "src"
 
 [install]
 library = true


### PR DESCRIPTION
Currently the proposed preprocessor include for different precision does fail with:

```
❯ cat > app/my_quadpack.F90 <<EOF
module quadpack_single
use iso_fortran_env, only: wp => real32
#define MOD_INCLUDE=1
#include "quadpack.f90"
end module quadpack_single
EOF
❯ fpm build
 + gfortran -c app/my_quadpack.F90  -Wall -Wextra -Wimplicit-interface -fPIC -fmax-errors=1 -g -fcheck=bounds -fcheck=array-temps -fbacktrace -fcoarray=single -J build/gfortran_2A42023B310FA28D/quad-prec -I build/gfortran_2A42023B310FA28D/quad-prec  -o build/gfortran_2A42023B310FA28D/quad-prec/app_my_quadpack.F90.o
app/my_quadpack.F90:5:2:

    5 | end module quadpack_single
      |  1~~~~~~~~~~~~~
Fatal Error: quadpack.F90: No such file or directory
compilation terminated.
```

However, if this projects exports a `library.include-dir = "src"` fpm will find and include the source file correctly.

See https://fpm.fortran-lang.org/en/spec/manifest.html#include-directory